### PR TITLE
fgen: bugfix for Snow Leopard

### DIFF
--- a/devel/fgen/Portfile
+++ b/devel/fgen/Portfile
@@ -4,13 +4,13 @@ PortSystem      1.0
 
 name            fgen
 version         0.3
-revision        0
+revision        1
 categories      devel
 platforms       darwin
 license         GPL-2+
 maintainers     {@kamischi web.de:karl-michael.schindler} openmaintainer
 homepage        http://hpux.connect.org.uk/hppd/hpux/Misc/${name}-${version}
-master_sites    http://www.ibiblio.org/pub/Linux/devel/lang/fortran/
+master_sites    https://www.ibiblio.org/pub/Linux/devel/lang/fortran/
 extract.suffix  .tgz
 checksums       rmd160  2bdd6d8b2f7625a2005b9bbd5eff103fe7b47ac6 \
                 sha256  1513f326ebc95c7116f7d34ddb535eeec6e39ec27a089ba19f4ca6f00afc6541 \
@@ -29,8 +29,15 @@ FGEN - makefile generator (for GNU make) for fortran 77/90 code \
 \n
 
 # This is required to rebuild the tools with substitutions and build the man files.
-post-build {
-    system -W ${worksrcpath} "touch -A -01 fgen f2html && make all"
+# On Snow Leopard, touch does not have the option -A
+if {${os.major} <= 10} {
+    post-build {
+        system -W ${worksrcpath} "sleep 1 && touch fgen f2html && make all"
+    }
+} else {
+    post-build {
+        system -W ${worksrcpath} "touch -A -01 fgen f2html && make all"
+    }
 }
 
 destroot {


### PR DESCRIPTION
#### Description

fgen: Bugfix for Snow Leopard

###### Type(s)

- [x] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on

macOS 13.4.1 22F770820d arm64
Xcode 14.3.1 14E300c
macOS x.y
( I have no access to Snow Leopard, so let's see, what the build queue reports.)

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? https://trac.macports.org/ticket/67862
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried a full install with `sudo port -vst install`? -vst fails at unpacking; -vs works.
- [x] tested basic functionality of all binary files?

