### PR TITLE
x86_64-binutils: update to 2.42 and fix

### DIFF
--- a/cross/x86_64-binutils/Portfile
+++ b/cross/x86_64-binutils/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           crossbinutils 1.0
 
 name                x86_64-binutils
-version             2.41
+version             2.42
 revision            0
 maintainers         {@kamischi web.de:karl-michael.schindler} \
                     openmaintainer
@@ -24,9 +24,13 @@ if {$subport eq $name} {
 foreach ostarget {linux dragonfly freebsd netbsd openbsd} {
     subport x86_64-${ostarget}-binutils {
         crossbinutils.setup     x86_64-${ostarget} ${version}
+        depends_lib             port:$name
         configure.args-append   --disable-werror
         if {${ostarget} eq "linux"} {
             depends_build-append    port:bison
+        }
+        post-destroot {
+            delete ${destroot}${prefix}/share/doc/x86_64-binutils
         }
     }
 }
@@ -38,6 +42,7 @@ subport x86_64-embedded-binutils {
         --disable-werror
 
     post-destroot {
+        delete      ${destroot}${prefix}/share/doc/x86_64-binutils
         file rename ${destroot}${prefix}/x86_64-unknown-elf/bin \
                     ${destroot}${prefix}/x86_64-embedded
         file rename ${destroot}${prefix}/x86_64-unknown-elf/lib \


### PR DESCRIPTION
Fixes clash of doc files https://trac.macports.org/ticket/70335

#### Description

Update to newer upstream version (2.42). Also resolves conflicting docs of binutils ports

###### Type(s)

- [x] bugfix
- [x] enhancement
- [ ] security fix

###### Tested on

macOS 14.5 23F79 arm64
Xcode 15.4 15F31d

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [x] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [x] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [x] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL in commit message? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [x] checked your Portfile with `port lint --nitpick`?
- [x] tried existing tests with `sudo port test`?
- [x] tried a full install with `sudo port -vst install`?    (Note: -t created an error in the extract phase)
- [x] tested basic functionality of all binary files?
- [] checked that the Portfile's most important [variants](https://trac.macports.org/wiki/Variants) haven't been broken?
